### PR TITLE
print current namespace last, to improve readabilty of long lists

### DIFF
--- a/cmd/ns.go
+++ b/cmd/ns.go
@@ -46,7 +46,7 @@ type NsOptions struct {
 // NewNsOptions provides an instance of NsOptions with default values
 func NewNsOptions(streams genericclioptions.IOStreams) *NsOptions {
 	return &NsOptions{
-		configFlags: genericclioptions.NewConfigFlags(),
+		configFlags: genericclioptions.NewConfigFlags(true),
 		IOStreams:   streams,
 	}
 }
@@ -170,12 +170,17 @@ func (o *NsOptions) printNamespaces(namespaces []string) error {
 	}
 	currentNS := o.rawConfig.Contexts[o.rawConfig.CurrentContext].Namespace
 
+	current := false
 	for _, ns := range namespaces {
 		if ns == currentNS {
-			red.Fprintf(o.Out, "%s\n", ns)
+			current = true // postpone printing the current namespace
 		} else {
 			fmt.Fprintf(o.Out, "%s\n", ns)
 		}
+	}
+
+	if current {
+		red.Fprintf(o.Out, "%s\n", currentNS)
 	}
 
 	return nil


### PR DESCRIPTION
- print current namespace last, to improve readabilty of long lists
- use persistent config according to commit https://github.com/kubernetes/cli-runtime/commit/160e5ab67a77ca4f91eb26b33bde26a6c024b999